### PR TITLE
Fix deprecation warnings

### DIFF
--- a/overmind/provisioning/controllers.py
+++ b/overmind/provisioning/controllers.py
@@ -1,8 +1,8 @@
-from libcloud import types
-from libcloud.base import NodeAuthPassword, NodeAuthSSHKey, Node
-from libcloud.base import NodeImage, NodeSize, NodeLocation
-from libcloud.providers import get_driver
-from libcloud.deployment import SSHKeyDeployment
+from libcloud.compute import types
+from libcloud.compute.base import NodeAuthPassword, NodeAuthSSHKey, Node
+from libcloud.compute.base import NodeImage, NodeSize, NodeLocation
+from libcloud.compute.providers import get_driver
+from libcloud.compute.deployment import SSHKeyDeployment
 from provisioning import plugins
 from django.conf import settings
 import copy, logging

--- a/overmind/provisioning/plugins/dedicated.py
+++ b/overmind/provisioning/plugins/dedicated.py
@@ -1,6 +1,6 @@
 # Dedicated Hardware plugin
-from libcloud.base import ConnectionKey, NodeDriver, Node
-from libcloud.types import NodeState
+from libcloud.compute.base import ConnectionKey, NodeDriver, Node
+from libcloud.compute.types import NodeState
 
 display_name = "Dedicated Hardware"
 access_key   = None

--- a/overmind/provisioning/plugins/hetzner.py
+++ b/overmind/provisioning/plugins/hetzner.py
@@ -1,6 +1,6 @@
 # Hetzner plugin
-from libcloud.base import ConnectionUserAndKey, NodeDriver, Node
-from libcloud.types import NodeState, InvalidCredsException
+from libcloud.compute.base import ConnectionUserAndKey, NodeDriver, Node
+from libcloud.compute.types import NodeState, InvalidCredsException
 import httplib2
 import simplejson as json
 from urllib import urlencode


### PR DESCRIPTION
The current stable release of libcloud deprecates the API overmind uses - this changes the import to use the current API.
