### PR TITLE
Add a requirements file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+bin
+lib
+include
+distribute*.tar.gz
 *.pyc
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Django
+django-celery
+django-piston
+IPy
+apache-libcloud
+httplib2
+simplejson
+


### PR DESCRIPTION
I'm using the latest libcloud release to do my testing which obviously isn't packaged. So here is the requirements file I used.

I can (but haven't) updated the documentation yet - I would like to change it to describe _only_ the virtualenv approach, thoughts?
