### PR TITLE
Fix redirect to /overview/

### DIFF
--- a/overmind/urls.py
+++ b/overmind/urls.py
@@ -37,8 +37,8 @@ urlpatterns += patterns('',
     (r'^provider/(?P<provider_id>\d+)/delete/$',\
         'provisioning.views.deleteprovider'),
     (r'^node/(?P<node_id>\d+)/destroy/$', 'provisioning.views.destroynode'),
-    
-    #(r'^$', 'redirect_to', {'url': '/overview/'}),
+
+    (r'^$', redirect_to, {'url': '/overview/', 'permanent': False}),
 )
 
 # Users


### PR DESCRIPTION
There is a commented out redirect to /overview/ on the root. This fixes that that redirect - which is a much better option than our current 404 on the root.

I also set the redirect to be non-permanent, in case our use of the root url changes.
