### PR TITLE
Many ips per node

### DIFF
--- a/overmind/api/provisioning.py
+++ b/overmind/api/provisioning.py
@@ -161,7 +161,7 @@ class SizeHandler(BaseHandler):
 
 class NodeHandler(BaseHandler):
     fields = ('id', 'name', 'node_id', 'provider', 'image', 'location', 'size', 
-        'public_ip', 'private_ip', 'created_by', 'state', 'environment',
+        'public_ips', 'private_ips', 'created_by', 'state', 'environment',
         'destroyed_by', 'created_at', 'destroyed_at')
     model = Node
     

--- a/overmind/provisioning/controllers.py
+++ b/overmind/provisioning/controllers.py
@@ -97,7 +97,7 @@ class ProviderController():
             return e, None
         
         return None, {
-            'public_ip': node.public_ip[0],
+            'public_ips': node.public_ips,
             'node_id': node.id,
             'state': node.state,
             'extra': node.extra,

--- a/overmind/provisioning/models.py
+++ b/overmind/provisioning/models.py
@@ -409,7 +409,7 @@ class Node(models.Model):
     def create_ip(self, ip, position, is_public):
         ipaddr = IP(ip)
         return NodeIP.objects.create(
-            address=ipaddr.i.strFullsize(), position=position, version=ipaddr.version(),
+            address=ipaddr.strFullsize(), position=position, version=ipaddr.version(),
             is_public=is_public, node=self
         )
 


### PR DESCRIPTION
Here my pull request to enhance IP node model using libcloud >= 0.7, were public_ip and private_ip were renamed to public_ips and private_ips and represent a list of many ips.

I keep backward compatibility for public_ip and private_ip Node attribute in overmind, but it should be useless hence all parts using public_ip and private_ip were adapted.

I tested node creation / deletion and it work correctly (ORM cascade on this new NodeIP model)
