### PR TITLE
Many ips

### DIFF
--- a/overmind/api/provisioning.py
+++ b/overmind/api/provisioning.py
@@ -161,7 +161,7 @@ class SizeHandler(BaseHandler):
 
 class NodeHandler(BaseHandler):
     fields = ('id', 'name', 'node_id', 'provider', 'image', 'location', 'size', 
-        'public_ip', 'private_ip', 'created_by', 'state', 'environment',
+        'public_ips', 'private_ips', 'created_by', 'state', 'environment',
         'destroyed_by', 'created_at', 'destroyed_at')
     model = Node
     

--- a/overmind/provisioning/controllers.py
+++ b/overmind/provisioning/controllers.py
@@ -97,7 +97,7 @@ class ProviderController():
             return e, None
         
         return None, {
-            'public_ip': node.public_ip[0],
+            'public_ips': node.public_ips,
             'node_id': node.id,
             'state': node.state,
             'extra': node.extra,

--- a/overmind/provisioning/models.py
+++ b/overmind/provisioning/models.py
@@ -409,7 +409,7 @@ class Node(models.Model):
     def create_ip(self, ip, position, is_public):
         ipaddr = IP(ip)
         return NodeIP.objects.create(
-            address=ipaddr.i.strFullsize(), position=position, version=ipaddr.version(),
+            address=ipaddr.strFullsize(), position=position, version=ipaddr.version(),
             is_public=is_public, node=self
         )
 

--- a/overmind/provisioning/models.py
+++ b/overmind/provisioning/models.py
@@ -328,10 +328,11 @@ class NodeIP(models.Model):
         ('inet6', 6),
     )
     node = models.ForeignKey('Node', related_name='ips')
-    address = models.CharField(max_length=50)   # For IPv6 support, not fully supported in django < 1.3.2 (IIRC)
+    address = models.IPAddressField()
     is_public = models.BooleanField(default=True)
     version = models.IntegerField(choices=INET_FAMILIES, default=4)
     position = models.IntegerField()
+    interface_name = models.CharField(max_length=32, blank=True)
 
     def __unicode__(self):
         return "%s" % (self.address)
@@ -380,12 +381,12 @@ class Node(models.Model):
 
     @property
     def public_ips(self):
-        return self.ips.filter(is_public=True).all()
+        return self.ips.filter(is_public=True)
 
 
     @property
     def private_ips(self):
-        return self.ips.filter(is_public=False).all()
+        return self.ips.filter(is_public=False)
 
     # Backward compatibility properties
     @property

--- a/overmind/templates/overview.html
+++ b/overmind/templates/overview.html
@@ -27,7 +27,7 @@
     <h2>Nodes<span class="actions"><a href="/provider/update/">update</a></span></h2>
     <br />
     <ul class="node">
-        {% for row in nodes %}<li id="n_{{ row.node.provider.id }}_{{ row.node.id }}"><span class="name" data-tooltip="{{ row.data }}">{{ row.node.provider }} - {{ row.node.name }} - {{ row.node.public_ip }} - {{ row.node.state }}</span><span class="actions">{% for a in row.actions %}<a href="{% if a.confirmation %}javascript:confirmation('{{ a.confirmation }}', '{% endif %}/node/{{ row.node.id }}/{{ a.action }}{% if a.confirmation %}');{% endif %}">{{ a.label }}</a>{% endfor %}</span></li>
+        {% for row in nodes %}<li id="n_{{ row.node.provider.id }}_{{ row.node.id }}"><span class="name" data-tooltip="{{ row.data }}">{{ row.node.provider }} - {{ row.node.name }} - {{ row.node.public_ips.0 }} - {{ row.node.state }}</span><span class="actions">{% for a in row.actions %}<a href="{% if a.confirmation %}javascript:confirmation('{{ a.confirmation }}', '{% endif %}/node/{{ row.node.id }}/{{ a.action }}{% if a.confirmation %}');{% endif %}">{{ a.label }}</a>{% endfor %}</span></li>
         {% endfor %}
     </ul>
 {% endblock %}


### PR DESCRIPTION
Here a new pull request for management of multiples IPs per node as liblcoud >= 0.7 expose.

I rewrite NodeIP sync strategy to be consistent across multiples node updates and keep things sync correctly.

I kept public_ips and private_ips "helpers" in node. I think we should update templates to no more use public_ip
node attribute.
